### PR TITLE
Add --days option to channel_daily_posts.py

### DIFF
--- a/channel_daily_posts.py
+++ b/channel_daily_posts.py
@@ -42,9 +42,12 @@ def parse_date(date_str):
 
 def parse_days(days):
     """N日前から今日までの開始・終了タイムスタンプを返す"""
+    if days <= 0:
+        print(f"エラー: --days は 1 以上の整数を指定してください: {days}")
+        return None, None
     now = datetime.now()
     today = now.replace(hour=23, minute=59, second=59, microsecond=999999)
-    start = (now - timedelta(days=days)).replace(hour=0, minute=0, second=0, microsecond=0)
+    start = (now - timedelta(days=days - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
     return start.timestamp(), today.timestamp()
 
 
@@ -224,7 +227,9 @@ def main():
     # 期間を算出
     if args.days is not None:
         oldest_ts, latest_ts = parse_days(args.days)
-        start_date = (datetime.now() - timedelta(days=args.days)).strftime('%Y-%m-%d')
+        if oldest_ts is None or latest_ts is None:
+            return
+        start_date = (datetime.now() - timedelta(days=args.days - 1)).strftime('%Y-%m-%d')
         end_date = datetime.now().strftime('%Y-%m-%d')
         period_label = f"{start_date} ~ {end_date}（{args.days}日間）"
     else:


### PR DESCRIPTION
## Summary

`channel_daily_posts.py` に `--days` オプションを追加し、「今日からN日前まで」の期間指定による投稿取得を可能にした。

## Plan

### Context
現在 `--date` で1日分のみ取得可能。`--days` を追加して「今日からN日前まで」の期間指定を可能にする。

### 変更対象
- `channel_daily_posts.py`

### 変更内容

#### 1. `parse_arguments()` の変更
- `--date` を `required=False` に変更
- `--days` オプションを追加（整数、デフォルトなし）
- `--date` と `--days` のどちらか一方を必須とするバリデーション

#### 2. 期間計算ロジックの追加
- `--days N` が指定された場合: 今日から N日前までの期間を `oldest` / `latest` タイムスタンプに変換
- `--date` が指定された場合: 従来通り1日分
- 両方指定された場合: エラー

#### 3. `main()` の変更
- `--days` / `--date` に応じて `oldest_ts`, `latest_ts` を算出するよう分岐
- 表示メッセージを期間に応じて変更（「取得日付」→「取得期間」）

### 動作例
```bash
# 過去7日分を取得
python channel_daily_posts.py --channel C123 --days 7 --output outputs/posts.json

# 従来通り1日分
python channel_daily_posts.py --channel C123 --date 2026-03-01 --output outputs/posts.json
```

### 検証
- `--days 730` で正しい期間のタイムスタンプが生成されることを確認済み
- `--date` 単独でも従来通り動作することを確認済み
- 両方指定/両方未指定でエラーになることを確認済み

## Test plan
- [x] `--days 730` で期間取得が正しく動作することを実行確認
- [x] `--date` 単独での従来動作に影響がないこと
- [x] `--date` と `--days` 同時指定でエラー
- [x] 両方未指定でエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)