### PR TITLE
Refactor rate limit handling and unify conversations pagination

### DIFF
--- a/channel_daily_posts.py
+++ b/channel_daily_posts.py
@@ -7,6 +7,8 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 import time
 
+from slack_conversations import fetch_all_channel_history, fetch_all_thread_replies
+
 def parse_arguments():
     parser = argparse.ArgumentParser(description='特定のチャンネルの指定した日付の投稿とスレッドを全て取得します')
     parser.add_argument('--channel', type=str, required=True, help='チャンネルID')
@@ -73,70 +75,11 @@ def get_user_info(client, user_id):
 
 def get_channel_messages(client, channel_id, oldest, latest):
     """チャンネルのメッセージを取得"""
-    messages = []
-    try:
-        cursor = None
-        while True:
-            response = client.conversations_history(
-                channel=channel_id,
-                oldest=str(oldest),
-                latest=str(latest),
-                limit=200,
-                cursor=cursor
-            )
-            
-            if not response["ok"]:
-                print(f"メッセージ取得エラー: {response.get('error', 'Unknown error')}")
-                break
-            
-            batch_messages = response.get("messages", [])
-            messages.extend(batch_messages)
-            
-            # 次のページがあるかチェック
-            if response.get("has_more") and response.get("response_metadata", {}).get("next_cursor"):
-                cursor = response["response_metadata"]["next_cursor"]
-                time.sleep(0.5)  # APIレート制限対策
-            else:
-                break
-                
-    except SlackApiError as e:
-        print(f"メッセージ取得エラー: {e}")
-    
-    return messages
+    return fetch_all_channel_history(client, channel_id, oldest=oldest, latest=latest)
 
 def get_thread_replies(client, channel_id, thread_ts):
-    """スレッドの返信を取得"""
-    replies = []
-    try:
-        cursor = None
-        while True:
-            response = client.conversations_replies(
-                channel=channel_id,
-                ts=thread_ts,
-                limit=200,
-                cursor=cursor
-            )
-            
-            if not response["ok"]:
-                print(f"スレッド取得エラー: {response.get('error', 'Unknown error')}")
-                break
-            
-            batch_replies = response.get("messages", [])
-            # 最初のメッセージ（親メッセージ）は除外
-            if batch_replies:
-                replies.extend(batch_replies[1:] if cursor is None else batch_replies)
-            
-            # 次のページがあるかチェック
-            if response.get("has_more") and response.get("response_metadata", {}).get("next_cursor"):
-                cursor = response["response_metadata"]["next_cursor"]
-                time.sleep(0.5)  # APIレート制限対策
-            else:
-                break
-                
-    except SlackApiError as e:
-        print(f"スレッド取得エラー: {e}")
-    
-    return replies
+    """スレッドの返信を取得（親メッセージ除外）"""
+    return fetch_all_thread_replies(client, channel_id, thread_ts)
 
 def format_message_data(message, channel_info, user_cache, message_type="message"):
     """メッセージデータをフォーマット"""
@@ -297,7 +240,7 @@ def main():
                 all_data.append(formatted_reply)
                 thread_messages.append(reply)
             
-            time.sleep(0.5)  # APIレート制限対策
+            time.sleep(1.5)  # conversations.replies APIのレート制限対策（Tier 3: 50リクエスト/分）
     
     # 結果を保存
     if all_data:

--- a/inactive_channels.py
+++ b/inactive_channels.py
@@ -6,29 +6,10 @@ from datetime import datetime, timedelta, timezone
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from slack_rate_limit import handle_rate_limit
+
 # 定数定義
 INACTIVE_THRESHOLD_DAYS = 365  # 非アクティブと判定する日数
-
-def handle_rate_limit(func, *args, max_retries=5, base_delay=1, **kwargs):
-    """レート制限に対応するためのラッパー関数"""
-    for attempt in range(max_retries):
-        try:
-            return func(*args, **kwargs)
-        except SlackApiError as e:
-            if e.response["error"] == "ratelimited":
-                if attempt == max_retries - 1:
-                    print(f"最大再試行回数に達しました: {e}")
-                    raise
-                            # HTTP 429 Too Many Requestsの場合
-                if e.response.status_code == 429:
-                    retry_after = int(e.response.headers.get('Retry-After', 30))
-                    print(f"レート制限に達しました。{retry_after:.2f}秒待機します... (試行 {attempt + 1}/{max_retries})")
-                    time.sleep(retry_after)
-
-            else:
-                raise
-    
-    return None
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
@@ -88,7 +69,7 @@ def get_channel_last_message_time(client, channel_id):
         # 最新メッセージのタイムスタンプを取得
         latest_message = messages[0]
         timestamp = float(latest_message["ts"])
-        return datetime.fromtimestamp(timestamp)
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
     
     except SlackApiError as e:
         if e.response["error"] == "channel_not_found":

--- a/inactive_channels.py
+++ b/inactive_channels.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from slack_rate_limit import handle_rate_limit
+from slack_conversations import fetch_channel_history
 
 # 定数定義
 INACTIVE_THRESHOLD_DAYS = 365  # 非アクティブと判定する日数
@@ -52,25 +52,12 @@ def load_channels_from_json(json_file_path):
 def get_channel_last_message_time(client, channel_id):
     """チャンネルの最新メッセージの投稿時刻を取得"""
     try:
-        response = handle_rate_limit(
-            client.conversations_history,
-            channel=channel_id,
-            limit=1,
-            include_all_metadata=False
-        )
-        
-        if not response or not response["ok"]:
-            return None
-        
-        messages = response.get("messages", [])
-        if not messages:
-            return None
-        
-        # 最新メッセージのタイムスタンプを取得
-        latest_message = messages[0]
-        timestamp = float(latest_message["ts"])
-        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
-    
+        for messages in fetch_channel_history(client, channel_id, limit=1):
+            if messages:
+                timestamp = float(messages[0]["ts"])
+                return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        return None
+
     except SlackApiError as e:
         if e.response["error"] == "channel_not_found":
             print(f"    チャンネル {channel_id} が見つかりません（削除済みの可能性）")

--- a/slack_conversations.py
+++ b/slack_conversations.py
@@ -99,7 +99,8 @@ def fetch_thread_replies(
 
         if skip_parent and is_first_page and replies:
             replies = replies[1:]
-            is_first_page = False
+        # 最初の API 呼び出し後は、replies の有無に関わらず is_first_page を False にする
+        is_first_page = False
 
         yield replies
 

--- a/slack_conversations.py
+++ b/slack_conversations.py
@@ -9,7 +9,6 @@ import time
 from typing import Dict, Generator, List, Optional
 
 from slack_sdk import WebClient
-from slack_sdk.errors import SlackApiError
 
 from slack_rate_limit import handle_rate_limit
 

--- a/slack_conversations.py
+++ b/slack_conversations.py
@@ -1,0 +1,126 @@
+"""
+Slack Conversations API shared module
+
+conversations.history / conversations.replies の呼び出し・ページネーション・レート制限を共通化し、
+各スクリプトはフィルタリングと結果加工のみ担当する。
+"""
+
+import time
+from typing import Dict, Generator, List, Optional
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+from slack_rate_limit import handle_rate_limit
+
+# conversations.history / conversations.replies は Tier 3 (50 req/min)
+_TIER3_INTERVAL = 1.5
+
+
+def fetch_channel_history(
+    client: WebClient,
+    channel_id: str,
+    oldest: Optional[float] = None,
+    latest: Optional[float] = None,
+    limit: int = 200,
+) -> Generator[List[Dict], None, None]:
+    """conversations.history をページベースで呼び出し、1ページ分の messages を yield するジェネレータ。"""
+    cursor = None
+
+    while True:
+        kwargs = {"channel": channel_id, "limit": limit}
+        if oldest is not None:
+            kwargs["oldest"] = str(oldest)
+        if latest is not None:
+            kwargs["latest"] = str(latest)
+        if cursor is not None:
+            kwargs["cursor"] = cursor
+
+        response = handle_rate_limit(client.conversations_history, **kwargs)
+
+        if not response or not response.get("ok", False):
+            break
+
+        messages = response.get("messages", [])
+        yield messages
+
+        if response.get("has_more") and response.get("response_metadata", {}).get("next_cursor"):
+            cursor = response["response_metadata"]["next_cursor"]
+            time.sleep(_TIER3_INTERVAL)
+        else:
+            break
+
+
+def fetch_all_channel_history(
+    client: WebClient,
+    channel_id: str,
+    oldest: Optional[float] = None,
+    latest: Optional[float] = None,
+    limit: int = 200,
+) -> List[Dict]:
+    """fetch_channel_history をフラット化し、全ページの全メッセージを1つのリストで返す。"""
+    all_messages = []
+    for messages in fetch_channel_history(client, channel_id, oldest, latest, limit):
+        all_messages.extend(messages)
+    return all_messages
+
+
+def fetch_thread_replies(
+    client: WebClient,
+    channel_id: str,
+    thread_ts: str,
+    oldest: Optional[float] = None,
+    latest: Optional[float] = None,
+    limit: int = 200,
+    skip_parent: bool = True,
+) -> Generator[List[Dict], None, None]:
+    """conversations.replies をページベースで呼び出し、1ページ分の replies を yield するジェネレータ。
+
+    skip_parent=True の場合、最初のページの先頭メッセージ（親メッセージ）を除外する。
+    """
+    cursor = None
+    is_first_page = True
+
+    while True:
+        kwargs = {"channel": channel_id, "ts": thread_ts, "limit": limit}
+        if oldest is not None:
+            kwargs["oldest"] = str(oldest)
+        if latest is not None:
+            kwargs["latest"] = str(latest)
+        if cursor is not None:
+            kwargs["cursor"] = cursor
+
+        response = handle_rate_limit(client.conversations_replies, **kwargs)
+
+        if not response or not response.get("ok", False):
+            break
+
+        replies = response.get("messages", [])
+
+        if skip_parent and is_first_page and replies:
+            replies = replies[1:]
+            is_first_page = False
+
+        yield replies
+
+        if response.get("has_more") and response.get("response_metadata", {}).get("next_cursor"):
+            cursor = response["response_metadata"]["next_cursor"]
+            time.sleep(_TIER3_INTERVAL)
+        else:
+            break
+
+
+def fetch_all_thread_replies(
+    client: WebClient,
+    channel_id: str,
+    thread_ts: str,
+    oldest: Optional[float] = None,
+    latest: Optional[float] = None,
+    limit: int = 200,
+    skip_parent: bool = True,
+) -> List[Dict]:
+    """fetch_thread_replies をフラット化し、全ページの全返信を1つのリストで返す。"""
+    all_replies = []
+    for replies in fetch_thread_replies(client, channel_id, thread_ts, oldest, latest, limit, skip_parent):
+        all_replies.extend(replies)
+    return all_replies

--- a/slack_rate_limit.py
+++ b/slack_rate_limit.py
@@ -1,0 +1,54 @@
+"""
+Slack API rate limit handling shared module
+
+全 Slack API 呼び出しで共通利用するレート制限ハンドラ。
+Retry-After ヘッダーがあればその値を使用し、なければ指数バックオフで待機する。
+"""
+
+import time
+
+from slack_sdk.errors import SlackApiError
+
+
+def handle_rate_limit(func, *args, max_retries=5, base_delay=1, **kwargs):
+    """レート制限に対応するためのラッパー関数
+
+    Retry-After ヘッダーがある場合はその値を使用し、
+    ない場合は base_delay を基にした指数バックオフ (base_delay * 2^attempt) を適用する。
+    """
+    status_code = None
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except SlackApiError as e:
+            # Slack が ratelimited を返した場合はリトライする
+            if e.response["error"] == "ratelimited":
+                if attempt == max_retries - 1:
+                    print(f"最大再試行回数に達しました: {e}")
+                    raise
+                status_code = getattr(e.response, "status_code", None)
+                if status_code == 429:
+                    backoff = base_delay * (2 ** attempt)
+                    retry_after = int(e.response.headers.get("Retry-After", backoff))
+                    print(
+                        f"レート制限に達しました。{retry_after}秒待機します... "
+                        f"(試行 {attempt + 1}/{max_retries})"
+                    )
+                    time.sleep(retry_after)
+                elif status_code is None or status_code >= 500:
+                    fallback_delay = base_delay * (2 ** attempt)
+                    print(
+                        f"サーバーエラー (status_code={status_code})。"
+                        f"{fallback_delay}秒待機します... (試行 {attempt + 1}/{max_retries})"
+                    )
+                    time.sleep(fallback_delay)
+                else:
+                    # 4xx (429以外) はリトライしても解決しない
+                    raise
+            else:
+                raise
+
+    raise SlackApiError(
+        f"最大再試行回数 ({max_retries}) に達しました。(status_code={status_code})",
+        response=None,
+    )

--- a/slack_search.py
+++ b/slack_search.py
@@ -11,54 +11,12 @@ from typing import Dict, Generator, List, Optional
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from slack_rate_limit import handle_rate_limit
+
 
 class SlackSearchError(Exception):
     """search.messages API 固有のエラー"""
     pass
-
-
-def handle_rate_limit(func, *args, max_retries=5, base_delay=1, **kwargs):
-    """レート制限に対応するためのラッパー関数
-
-    Retry-After ヘッダーがある場合はその値を使用し、
-    ない場合は base_delay を基にした指数バックオフ (base_delay * 2^attempt) を適用する。
-    """
-    for attempt in range(max_retries):
-        try:
-            return func(*args, **kwargs)
-        except SlackApiError as e:
-            # Slack が ratelimited を返した場合はリトライする
-            if e.response["error"] == "ratelimited":
-                if attempt == max_retries - 1:
-                    print(f"最大再試行回数に達しました: {e}")
-                    raise
-                # 通常は 429 + Retry-After が返る想定だが、
-                # status_code が無い / 429 でない場合にもフォールバックで待機する
-                status_code = getattr(e.response, "status_code", None)
-                if status_code == 429:
-                    backoff = base_delay * (2 ** attempt)
-                    retry_after = int(e.response.headers.get("Retry-After", backoff))
-                    print(
-                        f"レート制限に達しました。{retry_after}秒待機します... "
-                        f"(試行 {attempt + 1}/{max_retries})"
-                    )
-                    time.sleep(retry_after)
-                else:
-                    # フォールバックの指数バックオフ
-                    fallback_delay = base_delay * (2 ** attempt)
-                    print(
-                        f"レート制限 (非 429 または status_code 不明) に達しました。"
-                        f"{fallback_delay}秒待機します... (試行 {attempt + 1}/{max_retries})"
-                    )
-                    time.sleep(fallback_delay)
-            else:
-                raise
-
-    # ここに到達するのは通常想定していないが、安全のため明示的に例外を投げる
-    raise SlackApiError(
-        "レート制限ハンドラで最大再試行回数に達しましたが、SlackApiError が再送時に伝播しませんでした。",
-        response=None,
-    )
 
 
 def build_query(

--- a/tests/test_channel_daily_posts.py
+++ b/tests/test_channel_daily_posts.py
@@ -1,0 +1,210 @@
+"""Tests for channel_daily_posts module"""
+
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from channel_daily_posts import (
+    get_channel_messages,
+    get_thread_replies,
+    format_message_data,
+    parse_date,
+    parse_days,
+)
+
+
+def _make_history_response(messages, has_more=False, next_cursor=None):
+    """conversations_history レスポンスのモックを生成"""
+    data = {
+        "ok": True,
+        "messages": messages,
+        "has_more": has_more,
+        "response_metadata": {"next_cursor": next_cursor or ""},
+    }
+    resp = MagicMock()
+    resp.__getitem__ = lambda self, key: data[key]
+    resp.__bool__ = lambda self: True
+    resp.get = lambda key, default=None: data.get(key, default)
+    return resp
+
+
+def _make_replies_response(messages, has_more=False, next_cursor=None):
+    """conversations_replies レスポンスのモックを生成"""
+    return _make_history_response(messages, has_more, next_cursor)
+
+
+# --- get_channel_messages ---
+
+
+class TestGetChannelMessages:
+    @patch("channel_daily_posts.time.sleep")
+    def test_single_page(self, mock_sleep):
+        """1ページ分のメッセージを全て返す"""
+        client = MagicMock()
+        msgs = [{"ts": "100.0", "text": "a"}, {"ts": "101.0", "text": "b"}]
+        client.conversations_history.return_value = _make_history_response(msgs)
+
+        result = get_channel_messages(client, "C123", 99.0, 200.0)
+
+        assert len(result) == 2
+        assert result[0]["text"] == "a"
+        assert result[1]["text"] == "b"
+
+    @patch("channel_daily_posts.time.sleep")
+    def test_multiple_pages(self, mock_sleep):
+        """複数ページにまたがるメッセージを全て返す"""
+        client = MagicMock()
+        page1 = [{"ts": "100.0", "text": "a"}]
+        page2 = [{"ts": "101.0", "text": "b"}]
+        client.conversations_history.side_effect = [
+            _make_history_response(page1, has_more=True, next_cursor="cursor1"),
+            _make_history_response(page2),
+        ]
+
+        result = get_channel_messages(client, "C123", 99.0, 200.0)
+
+        assert len(result) == 2
+        assert result[0]["text"] == "a"
+        assert result[1]["text"] == "b"
+
+    @patch("channel_daily_posts.time.sleep")
+    def test_empty_channel(self, mock_sleep):
+        """メッセージがない場合は空リスト"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response([])
+
+        result = get_channel_messages(client, "C123", 99.0, 200.0)
+        assert result == []
+
+    @patch("channel_daily_posts.time.sleep")
+    def test_passes_oldest_and_latest(self, mock_sleep):
+        """oldest と latest パラメータが正しく渡される"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response([])
+
+        get_channel_messages(client, "C123", 1000.0, 2000.0)
+
+        call_kwargs = client.conversations_history.call_args[1]
+        assert call_kwargs["oldest"] == str(1000.0)
+        assert call_kwargs["latest"] == str(2000.0)
+        assert call_kwargs["channel"] == "C123"
+
+
+# --- get_thread_replies ---
+
+
+class TestGetThreadReplies:
+    @patch("channel_daily_posts.time.sleep")
+    def test_excludes_parent_message(self, mock_sleep):
+        """親メッセージ（先頭）を除外して返す"""
+        client = MagicMock()
+        parent = {"ts": "100.0", "text": "parent"}
+        reply1 = {"ts": "100.1", "text": "reply1"}
+        reply2 = {"ts": "100.2", "text": "reply2"}
+        client.conversations_replies.return_value = _make_replies_response(
+            [parent, reply1, reply2]
+        )
+
+        result = get_thread_replies(client, "C123", "100.0")
+
+        assert len(result) == 2
+        assert result[0]["text"] == "reply1"
+        assert result[1]["text"] == "reply2"
+
+    @patch("channel_daily_posts.time.sleep")
+    def test_multiple_pages_excludes_parent_only_on_first(self, mock_sleep):
+        """複数ページの場合、親メッセージは最初のページでのみ除外"""
+        client = MagicMock()
+        page1 = [{"ts": "100.0", "text": "parent"}, {"ts": "100.1", "text": "r1"}]
+        page2 = [{"ts": "100.2", "text": "r2"}]
+        client.conversations_replies.side_effect = [
+            _make_replies_response(page1, has_more=True, next_cursor="cur1"),
+            _make_replies_response(page2),
+        ]
+
+        result = get_thread_replies(client, "C123", "100.0")
+
+        assert len(result) == 2
+        assert result[0]["text"] == "r1"
+        assert result[1]["text"] == "r2"
+
+    @patch("channel_daily_posts.time.sleep")
+    def test_no_replies(self, mock_sleep):
+        """返信がない場合は空リスト"""
+        client = MagicMock()
+        client.conversations_replies.return_value = _make_replies_response([])
+
+        result = get_thread_replies(client, "C123", "100.0")
+        assert result == []
+
+
+# --- parse_date ---
+
+
+class TestParseDate:
+    def test_valid_date(self):
+        """正常な日付文字列をパースできる"""
+        oldest, latest = parse_date("2024-06-15")
+        assert oldest is not None
+        assert latest is not None
+        assert latest > oldest
+
+    def test_invalid_date_returns_none(self):
+        """不正な日付文字列は (None, None)"""
+        oldest, latest = parse_date("not-a-date")
+        assert oldest is None
+        assert latest is None
+
+
+# --- parse_days ---
+
+
+class TestParseDays:
+    def test_valid_days(self):
+        """正の整数で開始・終了タイムスタンプを返す"""
+        oldest, latest = parse_days(7)
+        assert oldest is not None
+        assert latest is not None
+        assert latest > oldest
+
+    def test_zero_days_returns_none(self):
+        """0日はエラー"""
+        oldest, latest = parse_days(0)
+        assert oldest is None
+        assert latest is None
+
+
+# --- format_message_data ---
+
+
+class TestFormatMessageData:
+    def test_formats_message_correctly(self):
+        """メッセージを正しくフォーマットする"""
+        message = {
+            "ts": "1700000000.000000",
+            "user": "U123",
+            "text": "hello world",
+            "thread_ts": None,
+            "reply_count": 0,
+            "reactions": [],
+            "attachments": [],
+            "files": [],
+            "blocks": [],
+        }
+        channel_info = {"id": "C123", "name": "general"}
+        user_cache = {
+            "U123": {
+                "name": "testuser",
+                "profile": {"display_name": "Test User"},
+            }
+        }
+
+        result = format_message_data(message, channel_info, user_cache, "message")
+
+        assert result["channel_id"] == "C123"
+        assert result["channel_name"] == "general"
+        assert result["user_id"] == "U123"
+        assert result["user_name"] == "testuser"
+        assert result["text"] == "hello world"
+        assert result["type"] == "message"

--- a/tests/test_inactive_channels.py
+++ b/tests/test_inactive_channels.py
@@ -56,19 +56,11 @@ class TestLoadChannelsFromJson:
 
 
 class TestGetChannelLastMessageTime:
-    def _make_response(self, messages):
-        resp = MagicMock()
-        data = {"ok": True, "messages": messages}
-        resp.__getitem__ = lambda self, key: data[key]
-        resp.__bool__ = lambda self: True
-        resp.get = lambda key, default=None: data.get(key, default)
-        return resp
-
-    @patch("inactive_channels.handle_rate_limit")
-    def test_returns_datetime_of_latest_message(self, mock_hrl):
+    @patch("inactive_channels.fetch_channel_history")
+    def test_returns_datetime_of_latest_message(self, mock_fetch):
         """最新メッセージのタイムスタンプを datetime で返す"""
         ts = "1700000000.000000"
-        mock_hrl.return_value = self._make_response([{"ts": ts}])
+        mock_fetch.return_value = iter([[{"ts": ts}]])
         client = MagicMock()
 
         result = get_channel_last_message_time(client, "C123")
@@ -76,30 +68,30 @@ class TestGetChannelLastMessageTime:
         assert isinstance(result, datetime)
         assert result == datetime.fromtimestamp(1700000000.0, tz=timezone.utc)
 
-    @patch("inactive_channels.handle_rate_limit")
-    def test_no_messages_returns_none(self, mock_hrl):
+    @patch("inactive_channels.fetch_channel_history")
+    def test_no_messages_returns_none(self, mock_fetch):
         """メッセージが空の場合は None"""
-        mock_hrl.return_value = self._make_response([])
+        mock_fetch.return_value = iter([[]])
         client = MagicMock()
 
         assert get_channel_last_message_time(client, "C123") is None
 
-    @patch("inactive_channels.handle_rate_limit")
-    def test_channel_not_found_returns_none(self, mock_hrl):
+    @patch("inactive_channels.fetch_channel_history")
+    def test_channel_not_found_returns_none(self, mock_fetch):
         """channel_not_found エラーで None"""
         error_resp = MagicMock()
         error_resp.__getitem__ = lambda self, key: "channel_not_found" if key == "error" else None
-        mock_hrl.side_effect = SlackApiError("not found", response=error_resp)
+        mock_fetch.side_effect = SlackApiError("not found", response=error_resp)
         client = MagicMock()
 
         assert get_channel_last_message_time(client, "C123") is None
 
-    @patch("inactive_channels.handle_rate_limit")
-    def test_not_in_channel_returns_none(self, mock_hrl):
+    @patch("inactive_channels.fetch_channel_history")
+    def test_not_in_channel_returns_none(self, mock_fetch):
         """not_in_channel エラーで None"""
         error_resp = MagicMock()
         error_resp.__getitem__ = lambda self, key: "not_in_channel" if key == "error" else None
-        mock_hrl.side_effect = SlackApiError("no access", response=error_resp)
+        mock_fetch.side_effect = SlackApiError("no access", response=error_resp)
         client = MagicMock()
 
         assert get_channel_last_message_time(client, "C123") is None

--- a/tests/test_inactive_channels.py
+++ b/tests/test_inactive_channels.py
@@ -1,7 +1,6 @@
 """Tests for inactive_channels module"""
 
 import json
-import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_inactive_channels.py
+++ b/tests/test_inactive_channels.py
@@ -1,0 +1,193 @@
+"""Tests for inactive_channels module"""
+
+import json
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from slack_sdk.errors import SlackApiError
+
+from inactive_channels import (
+    check_inactive_channels,
+    get_channel_last_message_time,
+    load_channels_from_json,
+    save_results_to_json,
+)
+
+
+# --- load_channels_from_json ---
+
+
+class TestLoadChannelsFromJson:
+    def test_filters_public_and_private_channels(self, tmp_path):
+        """パブリック・プライベートチャンネルのみ返し、DM/グループDMは除外"""
+        data = {
+            "channels": [
+                {"id": "C1", "name": "general", "is_channel": True, "is_im": False, "is_mpim": False},
+                {"id": "C2", "name": "private", "is_group": True, "is_im": False, "is_mpim": False},
+                {"id": "D1", "name": "dm", "is_channel": False, "is_im": True, "is_mpim": False},
+                {"id": "G1", "name": "group_dm", "is_channel": False, "is_im": False, "is_mpim": True},
+            ]
+        }
+        json_path = tmp_path / "channels.json"
+        json_path.write_text(json.dumps(data), encoding="utf-8")
+
+        result = load_channels_from_json(str(json_path))
+
+        assert len(result) == 2
+        assert result[0]["id"] == "C1"
+        assert result[1]["id"] == "C2"
+
+    def test_file_not_found_returns_empty(self, tmp_path):
+        """存在しないファイルを指定すると空リスト"""
+        result = load_channels_from_json(str(tmp_path / "nonexistent.json"))
+        assert result == []
+
+    def test_invalid_json_returns_empty(self, tmp_path):
+        """不正なJSONファイルは空リスト"""
+        json_path = tmp_path / "bad.json"
+        json_path.write_text("{invalid", encoding="utf-8")
+
+        result = load_channels_from_json(str(json_path))
+        assert result == []
+
+
+# --- get_channel_last_message_time ---
+
+
+class TestGetChannelLastMessageTime:
+    def _make_response(self, messages):
+        resp = MagicMock()
+        data = {"ok": True, "messages": messages}
+        resp.__getitem__ = lambda self, key: data[key]
+        resp.__bool__ = lambda self: True
+        resp.get = lambda key, default=None: data.get(key, default)
+        return resp
+
+    @patch("inactive_channels.handle_rate_limit")
+    def test_returns_datetime_of_latest_message(self, mock_hrl):
+        """最新メッセージのタイムスタンプを datetime で返す"""
+        ts = "1700000000.000000"
+        mock_hrl.return_value = self._make_response([{"ts": ts}])
+        client = MagicMock()
+
+        result = get_channel_last_message_time(client, "C123")
+
+        assert isinstance(result, datetime)
+        assert result == datetime.fromtimestamp(1700000000.0, tz=timezone.utc)
+
+    @patch("inactive_channels.handle_rate_limit")
+    def test_no_messages_returns_none(self, mock_hrl):
+        """メッセージが空の場合は None"""
+        mock_hrl.return_value = self._make_response([])
+        client = MagicMock()
+
+        assert get_channel_last_message_time(client, "C123") is None
+
+    @patch("inactive_channels.handle_rate_limit")
+    def test_channel_not_found_returns_none(self, mock_hrl):
+        """channel_not_found エラーで None"""
+        error_resp = MagicMock()
+        error_resp.__getitem__ = lambda self, key: "channel_not_found" if key == "error" else None
+        mock_hrl.side_effect = SlackApiError("not found", response=error_resp)
+        client = MagicMock()
+
+        assert get_channel_last_message_time(client, "C123") is None
+
+    @patch("inactive_channels.handle_rate_limit")
+    def test_not_in_channel_returns_none(self, mock_hrl):
+        """not_in_channel エラーで None"""
+        error_resp = MagicMock()
+        error_resp.__getitem__ = lambda self, key: "not_in_channel" if key == "error" else None
+        mock_hrl.side_effect = SlackApiError("no access", response=error_resp)
+        client = MagicMock()
+
+        assert get_channel_last_message_time(client, "C123") is None
+
+
+# --- check_inactive_channels ---
+
+
+class TestCheckInactiveChannels:
+    @patch("inactive_channels.time.sleep")
+    @patch("inactive_channels.get_channel_last_message_time")
+    def test_only_inactive_channels_returned(self, mock_get_time, mock_sleep):
+        """閾値より古いチャンネルのみ非アクティブとして返す"""
+        now = datetime.now(timezone.utc)
+        old_date = now - timedelta(days=400)
+        recent_date = now - timedelta(days=30)
+
+        mock_get_time.side_effect = [old_date, recent_date]
+
+        channels = [
+            {"id": "C1", "name": "old_channel"},
+            {"id": "C2", "name": "active_channel"},
+        ]
+        client = MagicMock()
+
+        result = check_inactive_channels(client, channels)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "C1"
+        assert result[0]["days_since_last_post"] >= 400
+
+    @patch("inactive_channels.time.sleep")
+    @patch("inactive_channels.get_channel_last_message_time")
+    def test_skips_channels_with_no_messages(self, mock_get_time, mock_sleep):
+        """メッセージ取得できないチャンネルはスキップ"""
+        now = datetime.now(timezone.utc)
+        old_date = now - timedelta(days=500)
+
+        mock_get_time.side_effect = [None, old_date]
+
+        channels = [
+            {"id": "C1", "name": "no_messages"},
+            {"id": "C2", "name": "old_channel"},
+        ]
+        client = MagicMock()
+
+        result = check_inactive_channels(client, channels)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "C2"
+
+
+# --- save_results_to_json ---
+
+
+class TestSaveResultsToJson:
+    def test_sorted_by_days_since_last_post_descending(self, tmp_path):
+        """days_since_last_post の降順でソートされる"""
+        inactive = [
+            {"name": "a", "days_since_last_post": 100, "last_message_time": "2024-01-01"},
+            {"name": "b", "days_since_last_post": 500, "last_message_time": "2023-01-01"},
+            {"name": "c", "days_since_last_post": 300, "last_message_time": "2023-06-01"},
+        ]
+        output_path = str(tmp_path / "result.json")
+
+        save_results_to_json(inactive, output_path)
+
+        with open(output_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        channels = data["inactive_channels"]
+        assert channels[0]["days_since_last_post"] == 500
+        assert channels[1]["days_since_last_post"] == 300
+        assert channels[2]["days_since_last_post"] == 100
+
+    def test_output_json_structure(self, tmp_path):
+        """出力JSONの構造が正しい"""
+        inactive = [
+            {"name": "a", "days_since_last_post": 400, "last_message_time": "2024-01-01"},
+        ]
+        output_path = str(tmp_path / "result.json")
+
+        save_results_to_json(inactive, output_path)
+
+        with open(output_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert "analysis_date" in data
+        assert data["threshold_days"] == 365
+        assert data["total_inactive_channels"] == 1
+        assert len(data["inactive_channels"]) == 1

--- a/tests/test_slack_conversations.py
+++ b/tests/test_slack_conversations.py
@@ -1,0 +1,310 @@
+"""Tests for slack_conversations module"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from slack_conversations import (
+    fetch_all_channel_history,
+    fetch_all_thread_replies,
+    fetch_channel_history,
+    fetch_thread_replies,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_history_response(messages, has_more=False, next_cursor=None):
+    """conversations.history / conversations.replies レスポンスのモック"""
+    data = {
+        "ok": True,
+        "messages": messages,
+        "has_more": has_more,
+        "response_metadata": {"next_cursor": next_cursor or ""},
+    }
+    resp = MagicMock()
+    resp.get = lambda key, default=None: data.get(key, default)
+    resp.__getitem__ = lambda self, key: data[key]
+    resp.__bool__ = lambda self: True
+    return resp
+
+
+def _make_slack_error(error_code, status_code=200, retry_after=1):
+    """SlackApiError のモックを生成するヘルパー"""
+    resp = MagicMock()
+    resp.__getitem__ = lambda self, key: error_code if key == "error" else None
+    resp.status_code = status_code
+    resp.headers = {"Retry-After": str(retry_after)}
+    return SlackApiError("error", resp)
+
+
+# ---------------------------------------------------------------------------
+# fetch_channel_history
+# ---------------------------------------------------------------------------
+
+
+class TestFetchChannelHistory:
+    @patch("slack_conversations.time.sleep")
+    def test_single_page(self, mock_sleep):
+        """1ページのみ（has_more=False）"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response(
+            [{"ts": "1.0", "text": "msg1"}], has_more=False
+        )
+        pages = list(fetch_channel_history(client, "C123"))
+        assert len(pages) == 1
+        assert pages[0] == [{"ts": "1.0", "text": "msg1"}]
+        mock_sleep.assert_not_called()
+
+    @patch("slack_conversations.time.sleep")
+    def test_multi_page_with_cursor(self, mock_sleep):
+        """has_more=True のときカーソルで次ページを取得する"""
+        client = MagicMock()
+        client.conversations_history.side_effect = [
+            _make_history_response([{"ts": "1.0"}], has_more=True, next_cursor="cursor1"),
+            _make_history_response([{"ts": "2.0"}], has_more=False),
+        ]
+        pages = list(fetch_channel_history(client, "C123"))
+        assert len(pages) == 2
+        assert pages[0] == [{"ts": "1.0"}]
+        assert pages[1] == [{"ts": "2.0"}]
+        # ページ間で Tier3 インターバルのスリープが入る
+        mock_sleep.assert_called_once_with(1.5)
+        # 2回目の呼び出しにカーソルが渡される
+        second_call_kwargs = client.conversations_history.call_args_list[1][1]
+        assert second_call_kwargs["cursor"] == "cursor1"
+
+    @patch("slack_conversations.time.sleep")
+    def test_three_pages_cursor_chained(self, mock_sleep):
+        """3ページのカーソルチェーンが正しく動作する"""
+        client = MagicMock()
+        client.conversations_history.side_effect = [
+            _make_history_response([{"ts": "1.0"}], has_more=True, next_cursor="c1"),
+            _make_history_response([{"ts": "2.0"}], has_more=True, next_cursor="c2"),
+            _make_history_response([{"ts": "3.0"}], has_more=False),
+        ]
+        pages = list(fetch_channel_history(client, "C123"))
+        assert len(pages) == 3
+        assert mock_sleep.call_count == 2
+        calls = client.conversations_history.call_args_list
+        assert "cursor" not in calls[0][1]
+        assert calls[1][1]["cursor"] == "c1"
+        assert calls[2][1]["cursor"] == "c2"
+
+    @patch("slack_conversations.time.sleep")
+    def test_empty_messages(self, mock_sleep):
+        """空のメッセージリストでも正常に動作する"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response([], has_more=False)
+        pages = list(fetch_channel_history(client, "C123"))
+        assert pages == [[]]
+        mock_sleep.assert_not_called()
+
+    @patch("slack_conversations.time.sleep")
+    def test_ok_false_breaks_loop(self, mock_sleep):
+        """ok=False のレスポンスでループを終了する"""
+        client = MagicMock()
+        resp = MagicMock()
+        resp.get = lambda key, default=None: False if key == "ok" else default
+        resp.__bool__ = lambda self: True
+        client.conversations_history.return_value = resp
+        pages = list(fetch_channel_history(client, "C123"))
+        assert pages == []
+
+    @patch("slack_conversations.time.sleep")
+    def test_oldest_and_latest_params_passed(self, mock_sleep):
+        """oldest / latest パラメータが API に渡される"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response([])
+        list(fetch_channel_history(client, "C123", oldest=1000.0, latest=2000.0))
+        kwargs = client.conversations_history.call_args[1]
+        assert kwargs["oldest"] == "1000.0"
+        assert kwargs["latest"] == "2000.0"
+
+    @patch("slack_rate_limit.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep):
+        """レート制限エラー時にリトライして成功する"""
+        client = MagicMock()
+        client.conversations_history.side_effect = [
+            _make_slack_error("ratelimited", status_code=429, retry_after=2),
+            _make_slack_error("ratelimited", status_code=429, retry_after=2),
+            _make_history_response([{"ts": "1.0"}], has_more=False),
+        ]
+        pages = list(fetch_channel_history(client, "C123"))
+        assert len(pages) == 1
+        assert pages[0] == [{"ts": "1.0"}]
+        assert client.conversations_history.call_count == 3
+        assert mock_sleep.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# fetch_all_channel_history
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAllChannelHistory:
+    @patch("slack_conversations.time.sleep")
+    def test_flattens_multiple_pages(self, mock_sleep):
+        """複数ページを1つのリストに結合する"""
+        client = MagicMock()
+        client.conversations_history.side_effect = [
+            _make_history_response([{"ts": "1.0"}, {"ts": "2.0"}], has_more=True, next_cursor="c1"),
+            _make_history_response([{"ts": "3.0"}], has_more=False),
+        ]
+        result = fetch_all_channel_history(client, "C123")
+        assert result == [{"ts": "1.0"}, {"ts": "2.0"}, {"ts": "3.0"}]
+
+    @patch("slack_conversations.time.sleep")
+    def test_empty_result(self, mock_sleep):
+        """空の結果を返す"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_history_response([])
+        result = fetch_all_channel_history(client, "C123")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_thread_replies
+# ---------------------------------------------------------------------------
+
+
+class TestFetchThreadReplies:
+    @patch("slack_conversations.time.sleep")
+    def test_skip_parent_true_removes_first_message(self, mock_sleep):
+        """skip_parent=True のとき最初のメッセージ（親）を除外する"""
+        client = MagicMock()
+        client.conversations_replies.return_value = _make_history_response(
+            [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}],
+            has_more=False,
+        )
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=True))
+        assert pages == [[{"ts": "1.1", "text": "reply1"}]]
+
+    @patch("slack_conversations.time.sleep")
+    def test_skip_parent_false_keeps_all(self, mock_sleep):
+        """skip_parent=False のとき全メッセージを返す"""
+        client = MagicMock()
+        client.conversations_replies.return_value = _make_history_response(
+            [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}],
+            has_more=False,
+        )
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=False))
+        assert pages == [[{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}]]
+
+    @patch("slack_conversations.time.sleep")
+    def test_skip_parent_only_applies_to_first_page(self, mock_sleep):
+        """skip_parent は1ページ目のみ適用され、2ページ目は全メッセージを返す"""
+        client = MagicMock()
+        client.conversations_replies.side_effect = [
+            _make_history_response(
+                [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}],
+                has_more=True,
+                next_cursor="c1",
+            ),
+            _make_history_response(
+                [{"ts": "1.2", "text": "reply2"}, {"ts": "1.3", "text": "reply3"}],
+                has_more=False,
+            ),
+        ]
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=True))
+        assert len(pages) == 2
+        # 1ページ目: 親メッセージ除外
+        assert pages[0] == [{"ts": "1.1", "text": "reply1"}]
+        # 2ページ目: 除外なし
+        assert pages[1] == [{"ts": "1.2", "text": "reply2"}, {"ts": "1.3", "text": "reply3"}]
+
+    @patch("slack_conversations.time.sleep")
+    def test_empty_first_page_sets_is_first_page_false(self, mock_sleep):
+        """1ページ目が空でも is_first_page が False になり、2ページ目で親を除外しない"""
+        client = MagicMock()
+        client.conversations_replies.side_effect = [
+            _make_history_response([], has_more=True, next_cursor="c1"),
+            _make_history_response(
+                [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}],
+                has_more=False,
+            ),
+        ]
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=True))
+        assert len(pages) == 2
+        assert pages[0] == []
+        # 2ページ目では親を除外しない（is_first_page が正しく False になっている）
+        assert pages[1] == [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply1"}]
+
+    @patch("slack_conversations.time.sleep")
+    def test_multi_page_cursor_pagination(self, mock_sleep):
+        """複数ページのカーソルページネーションが正しく動作する"""
+        client = MagicMock()
+        client.conversations_replies.side_effect = [
+            _make_history_response([{"ts": "1.0"}, {"ts": "1.1"}], has_more=True, next_cursor="c1"),
+            _make_history_response([{"ts": "1.2"}], has_more=True, next_cursor="c2"),
+            _make_history_response([{"ts": "1.3"}], has_more=False),
+        ]
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=False))
+        assert len(pages) == 3
+        assert mock_sleep.call_count == 2
+        calls = client.conversations_replies.call_args_list
+        assert "cursor" not in calls[0][1]
+        assert calls[1][1]["cursor"] == "c1"
+        assert calls[2][1]["cursor"] == "c2"
+
+    @patch("slack_conversations.time.sleep")
+    def test_oldest_latest_and_ts_params_passed(self, mock_sleep):
+        """ts / oldest / latest パラメータが API に渡される"""
+        client = MagicMock()
+        client.conversations_replies.return_value = _make_history_response([])
+        list(fetch_thread_replies(client, "C123", "1.5", oldest=1000.0, latest=2000.0))
+        kwargs = client.conversations_replies.call_args[1]
+        assert kwargs["ts"] == "1.5"
+        assert kwargs["oldest"] == "1000.0"
+        assert kwargs["latest"] == "2000.0"
+
+    @patch("slack_rate_limit.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep):
+        """レート制限エラー時にリトライして成功する"""
+        client = MagicMock()
+        client.conversations_replies.side_effect = [
+            _make_slack_error("ratelimited", status_code=429, retry_after=1),
+            _make_history_response(
+                [{"ts": "1.0", "text": "parent"}, {"ts": "1.1", "text": "reply"}],
+                has_more=False,
+            ),
+        ]
+        pages = list(fetch_thread_replies(client, "C123", "1.0", skip_parent=True))
+        assert pages == [[{"ts": "1.1", "text": "reply"}]]
+        assert client.conversations_replies.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+
+# ---------------------------------------------------------------------------
+# fetch_all_thread_replies
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAllThreadReplies:
+    @patch("slack_conversations.time.sleep")
+    def test_flattens_multiple_pages(self, mock_sleep):
+        """複数ページを1つのリストに結合する"""
+        client = MagicMock()
+        client.conversations_replies.side_effect = [
+            _make_history_response(
+                [{"ts": "1.0"}, {"ts": "1.1"}, {"ts": "1.2"}], has_more=True, next_cursor="c1"
+            ),
+            _make_history_response([{"ts": "1.3"}], has_more=False),
+        ]
+        result = fetch_all_thread_replies(client, "C123", "1.0", skip_parent=True)
+        # skip_parent=True: 1ページ目の先頭を除外 → [1.1, 1.2] + [1.3]
+        assert result == [{"ts": "1.1"}, {"ts": "1.2"}, {"ts": "1.3"}]
+
+    @patch("slack_conversations.time.sleep")
+    def test_skip_parent_false_includes_all(self, mock_sleep):
+        """skip_parent=False のとき全メッセージを含む"""
+        client = MagicMock()
+        client.conversations_replies.return_value = _make_history_response(
+            [{"ts": "1.0"}, {"ts": "1.1"}], has_more=False
+        )
+        result = fetch_all_thread_replies(client, "C123", "1.0", skip_parent=False)
+        assert result == [{"ts": "1.0"}, {"ts": "1.1"}]

--- a/tests/test_slack_search.py
+++ b/tests/test_slack_search.py
@@ -116,9 +116,8 @@ class TestHandleRateLimit:
 def _mock_search_response(matches, page=1, page_count=1):
     """search_messages API レスポンスのモックを生成"""
     resp = MagicMock()
-    resp.__getitem__ = lambda self, key: True if key == "ok" else None
-    resp.__bool__ = lambda self: True
-    resp.get = lambda key, default=None: {
+    data = {
+        "ok": True,
         "messages": {
             "matches": matches,
             "pagination": {
@@ -126,8 +125,11 @@ def _mock_search_response(matches, page=1, page_count=1):
                 "page_count": page_count,
                 "total_count": len(matches) * page_count,
             },
-        }
-    }.get(key, default)
+        },
+    }
+    resp.__getitem__ = lambda self, key: data[key]
+    resp.__bool__ = lambda self: True
+    resp.get = lambda key, default=None: data.get(key, default)
     return resp
 
 

--- a/tests/test_weekly_message_count.py
+++ b/tests/test_weekly_message_count.py
@@ -1,0 +1,154 @@
+"""Tests for weekly_message_count module"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from weekly_message_count import (
+    fetch_messages,
+    get_sunday_week_key,
+    aggregate_by_week,
+)
+
+
+def _make_response(messages, has_more=False, next_cursor=None):
+    """conversations API レスポンスのモックを生成"""
+    data = {
+        "ok": True,
+        "messages": messages,
+        "has_more": has_more,
+        "response_metadata": {"next_cursor": next_cursor or ""},
+    }
+    resp = MagicMock()
+    resp.__getitem__ = lambda self, key: data[key]
+    resp.__bool__ = lambda self: True
+    resp.get = lambda key, default=None: data.get(key, default)
+    return resp
+
+
+# --- fetch_messages ---
+
+
+class TestFetchMessages:
+    @patch("weekly_message_count.time.sleep")
+    def test_keyword_filter_on_parent_messages(self, mock_sleep):
+        """親メッセージからキーワードに一致するものだけを返す"""
+        client = MagicMock()
+        msgs = [
+            {"ts": "100.0", "text": "hello world", "reply_count": 0},
+            {"ts": "101.0", "text": "no match here", "reply_count": 0},
+            {"ts": "102.0", "text": "say Hello again", "reply_count": 0},
+        ]
+        client.conversations_history.return_value = _make_response(msgs)
+
+        result = fetch_messages(client, "C123", "hello", 30)
+
+        assert len(result) == 2
+        assert result[0]["ts"] == "100.0"
+        assert result[1]["ts"] == "102.0"
+
+    @patch("weekly_message_count.time.sleep")
+    def test_keyword_filter_on_thread_replies(self, mock_sleep):
+        """スレッド返信からもキーワードに一致するものを返す"""
+        client = MagicMock()
+        parent = {"ts": "100.0", "text": "no match", "reply_count": 1}
+        client.conversations_history.return_value = _make_response([parent])
+
+        reply_parent = {"ts": "100.0", "text": "no match"}
+        reply1 = {"ts": "100.1", "text": "hello from thread"}
+        reply2 = {"ts": "100.2", "text": "no match reply"}
+        client.conversations_replies.return_value = _make_response(
+            [reply_parent, reply1, reply2]
+        )
+
+        result = fetch_messages(client, "C123", "hello", 30)
+
+        assert len(result) == 1
+        assert result[0]["ts"] == "100.1"
+
+    @patch("weekly_message_count.time.sleep")
+    def test_deduplication_by_text(self, mock_sleep):
+        """同じテキストのメッセージは重複排除される"""
+        client = MagicMock()
+        msgs = [
+            {"ts": "100.0", "text": "hello", "reply_count": 0},
+            {"ts": "101.0", "text": "Hello", "reply_count": 0},
+        ]
+        client.conversations_history.return_value = _make_response(msgs)
+
+        result = fetch_messages(client, "C123", "hello", 30)
+
+        # "hello" と "Hello" は .strip().lower() で同一 → 重複排除
+        assert len(result) == 1
+
+    @patch("weekly_message_count.time.sleep")
+    def test_empty_channel(self, mock_sleep):
+        """メッセージがない場合は空リスト"""
+        client = MagicMock()
+        client.conversations_history.return_value = _make_response([])
+
+        result = fetch_messages(client, "C123", "hello", 30)
+        assert result == []
+
+    @patch("weekly_message_count.time.sleep")
+    def test_parent_message_skipped_in_replies(self, mock_sleep):
+        """スレッド返信の先頭（親メッセージ）はスキップされる"""
+        client = MagicMock()
+        parent = {"ts": "100.0", "text": "hello parent", "reply_count": 1}
+        client.conversations_history.return_value = _make_response([parent])
+
+        # replies の先頭は親メッセージ
+        reply_parent = {"ts": "100.0", "text": "hello parent"}
+        reply1 = {"ts": "100.1", "text": "hello reply"}
+        client.conversations_replies.return_value = _make_response(
+            [reply_parent, reply1]
+        )
+
+        result = fetch_messages(client, "C123", "hello", 30)
+
+        # 親は history から1件、reply から1件。親テキストは重複排除で1件のみ
+        texts = [m["text"] for m in result]
+        assert "hello parent" in texts
+        assert "hello reply" in texts
+
+
+# --- get_sunday_week_key ---
+
+
+class TestGetSundayWeekKey:
+    def test_sunday_is_start_of_week(self):
+        """日曜日は週の始まり"""
+        # 2024-06-16 is Sunday
+        ts = 1718496000.0  # 2024-06-16 00:00:00 UTC
+        week_key, start_date, end_date = get_sunday_week_key(ts)
+
+        assert start_date.weekday() == 6  # Sunday
+
+    def test_returns_week_key_format(self):
+        """YYYY-Www 形式の週キーを返す"""
+        ts = 1718496000.0
+        week_key, _, _ = get_sunday_week_key(ts)
+
+        assert "-W" in week_key
+
+
+# --- aggregate_by_week ---
+
+
+class TestAggregateByWeek:
+    def test_counts_messages_per_week(self):
+        """週ごとにメッセージを集計する"""
+        messages = [
+            {"ts": "1718496000.0"},  # 2024-06-16 (Sun)
+            {"ts": "1718582400.0"},  # 2024-06-17 (Mon) - same week
+            {"ts": "1719100800.0"},  # 2024-06-23 (Sun) - next week
+        ]
+
+        result = aggregate_by_week(messages)
+
+        total_count = sum(v["count"] for v in result.values())
+        assert total_count == 3
+
+    def test_empty_messages(self):
+        """空リストは空の集計結果"""
+        result = aggregate_by_week([])
+        assert result == {}

--- a/unanswered_mentions.py
+++ b/unanswered_mentions.py
@@ -7,6 +7,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 import time
 
+from slack_conversations import fetch_all_thread_replies, fetch_channel_history, fetch_thread_replies
 from slack_search import build_query, handle_rate_limit, search_messages
 
 def parse_arguments():
@@ -127,10 +128,10 @@ def get_channels_with_mentions_from_search(client, mentioned_user_id, days_ago, 
             if not matches:
                 break
             print(f"  {len(matches)}件のメッセージを取得")
-            for msg in matches:
-                channel_info = msg.get("channel", {})
-                if channel_info.get("id"):
-                    channels_with_mentions.add(channel_info["id"])
+            channels_with_mentions.update(
+                msg["channel"]["id"] for msg in matches
+                if msg.get("channel", {}).get("id")
+            )
     except Exception as e:
         print(f"検索APIエラー: {e}")
         return set()
@@ -141,56 +142,36 @@ def get_channels_with_mentions_from_search(client, mentioned_user_id, days_ago, 
 def get_messages_with_mentions(client, channel_id, mentioned_user_id, days_ago):
     """指定したチャンネルから特定のユーザーへのメンションを含むメッセージを取得（スレッド内も含む）"""
     all_messages = []
-    
-    # 検索対象の期間を設定
+
     oldest_time = (datetime.now(timezone.utc) - timedelta(days=days_ago)).timestamp()
     mention_pattern = f"<@{mentioned_user_id}>"
-    
+
     try:
-        cursor = None
-        while True:
-            # チャンネルの履歴を取得
-            response = handle_rate_limit(
-                client.conversations_history,
-                channel=channel_id,
-                oldest=str(oldest_time),
-                limit=200,
-                cursor=cursor
-            )
-            
-            if not response or not response["ok"]:
-                break
-            
-            messages = response.get("messages", [])
+        for messages in fetch_channel_history(client, channel_id, oldest=oldest_time):
             if not messages:
                 break
-            
-            # メンションを含むメッセージを抽出（リスト内包表記を使用）
+
+            # メンションを含むメッセージを抽出
             mention_messages = [
                 message for message in messages
                 if mention_pattern in message.get("text", "")
             ]
             all_messages.extend(mention_messages)
-            
+
             # スレッドのあるメッセージに対して、スレッド内のメンションもチェック
-            # reply_count > 0 はスレッドの親メッセージを示す
-            for message in messages:
-                if message.get("reply_count", 0) > 0:
-                    thread_mentions = get_thread_mentions(client, channel_id, message["ts"], mention_pattern, oldest_time)
-                    all_messages.extend(thread_mentions)
-            
-            # 次のページがあるかチェック
-            response_metadata = response.get("response_metadata", {})
-            next_cursor = response_metadata.get("next_cursor")
-            
-            if not next_cursor:
-                break
-            
-            cursor = next_cursor
-            time.sleep(1.5)  # search.messages APIのレート制限対策（Tier 3: 50リクエスト/分）
-        
+            threaded_messages = [
+                message for message in messages
+                if message.get("reply_count", 0) > 0
+            ]
+            thread_mentions = [
+                mention
+                for message in threaded_messages
+                for mention in get_thread_mentions(client, channel_id, message["ts"], mention_pattern, oldest_time)
+            ]
+            all_messages.extend(thread_mentions)
+
         return all_messages
-    
+
     except SlackApiError as e:
         print(f"メッセージ取得エラー ({channel_id}): {e}")
         return []
@@ -198,29 +179,17 @@ def get_messages_with_mentions(client, channel_id, mentioned_user_id, days_ago):
 def get_thread_mentions(client, channel_id, thread_ts, mention_pattern, oldest_time):
     """スレッド内のメンションを含むメッセージを取得"""
     thread_mentions = []
-    
+
     try:
-        response = handle_rate_limit(
-            client.conversations_replies,
-            channel=channel_id,
-            ts=thread_ts,
-            limit=200
-        )
-        
-        if response and response["ok"]:
-            replies = response.get("messages", [])
-            # 全てのメッセージをチェック（親メッセージも含む）
-            for reply in replies:
-                # 期間内かつメンションを含むメッセージを抽出
-                # thread_tsフィールドがあるものは返信メッセージ
-                if (mention_pattern in reply.get("text", "") and
-                    "thread_ts" in reply):  # スレッド内の返信のみ（親メッセージは除外）
-                    thread_mentions.append(reply)
-    
+        for replies in fetch_thread_replies(client, channel_id, thread_ts, skip_parent=False):
+            thread_mentions.extend([
+                reply for reply in replies
+                if mention_pattern in reply.get("text", "") and "thread_ts" in reply
+            ])
+
     except SlackApiError as e:
         print(f"スレッド取得エラー ({channel_id}, {thread_ts}): {e}")
-    
-    time.sleep(1.5)  # conversations.replies APIのレート制限対策（Tier 3: 50リクエスト/分）
+
     return thread_mentions
 
 def check_user_reactions_and_replies(client, channel_id, message, mentioned_user_id):
@@ -249,50 +218,31 @@ def check_user_reactions_and_replies(client, channel_id, message, mentioned_user
             print(f"[DEBUG] message type: {'parent' if message.get('reply_count', 0) > 0 else 'reply'}")
             
             # スレッドの返信を取得
-            thread_response = handle_rate_limit(
-                client.conversations_replies,
-                channel=channel_id,
-                ts=thread_ts_to_check,
-                limit=200
-            )
-            
-            if thread_response and thread_response["ok"]:
-                replies = thread_response.get("messages", [])
-                print(f"[DEBUG] スレッド内メッセージ数: {len(replies)}")
-                
-                # 最初のメッセージは元のメッセージなのでスキップ
-                for i, reply in enumerate(replies[1:], 1):
-                    reply_user = reply.get("user", "")
-                    reply_text = reply.get("text", "")[:50]
-                    print(f"[DEBUG] 返信{i}: user={reply_user}")
-                    print(f"[DEBUG] 返信{i}テキスト: {reply_text}...")
-                    print(f"[DEBUG] 対象ユーザー({mentioned_user_id})と一致? {reply_user == mentioned_user_id}")
-                    
-                    if reply.get("user") == mentioned_user_id:
-                        print(f"[DEBUG] ✅ スレッド内返信を発見!")
-                        return True, "reply", reply.get("text", "")[:100]
-                
-                print(f"[DEBUG] ❌ スレッド内に対象ユーザーの返信なし")
-            else:
-                print(f"[DEBUG] スレッド取得失敗: {thread_response.get('error', '不明') if thread_response else 'レスポンスなし'}")
+            replies = fetch_all_thread_replies(client, channel_id, thread_ts_to_check, skip_parent=False)
+            print(f"[DEBUG] スレッド内メッセージ数: {len(replies)}")
+
+            # 最初のメッセージは元のメッセージなのでスキップ
+            for i, reply in enumerate(replies[1:], 1):
+                reply_user = reply.get("user", "")
+                reply_text = reply.get("text", "")[:50]
+                print(f"[DEBUG] 返信{i}: user={reply_user}")
+                print(f"[DEBUG] 返信{i}テキスト: {reply_text}...")
+                print(f"[DEBUG] 対象ユーザー({mentioned_user_id})と一致? {reply_user == mentioned_user_id}")
+
+                if reply.get("user") == mentioned_user_id:
+                    print(f"[DEBUG] ✅ スレッド内返信を発見!")
+                    return True, "reply", reply.get("text", "")[:100]
+
+            print(f"[DEBUG] ❌ スレッド内に対象ユーザーの返信なし")
         
         # 3. 直後の返信もチェック（スレッドでない場合）
         # 元のメッセージの直後24時間以内にメンションされたユーザーからの投稿があるかチェック
         message_time = float(message_ts)
         one_day_later = message_time + 3600 * 24  # 24時間後
         
-        recent_response = handle_rate_limit(
-            client.conversations_history,
-            channel=channel_id,
-            oldest=str(message_time),
-            latest=str(one_day_later),
-            limit=50
-        )
-        
-        if recent_response and recent_response["ok"]:
-            recent_messages = recent_response.get("messages", [])
+        for recent_messages in fetch_channel_history(client, channel_id, oldest=message_time, latest=one_day_later, limit=50):
             for recent_msg in recent_messages:
-                if (recent_msg.get("user") == mentioned_user_id and 
+                if (recent_msg.get("user") == mentioned_user_id and
                     float(recent_msg["ts"]) > message_time):
                     return True, "followup", recent_msg.get("text", "")[:100]
     

--- a/weekly_message_count.py
+++ b/weekly_message_count.py
@@ -17,6 +17,55 @@ from typing import Dict, List
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from slack_conversations import fetch_all_channel_history, fetch_all_thread_replies
+
+
+def _extract_rich_text_elements(elements: list) -> str:
+    """rich_text ブロックの elements を再帰的にテキスト化"""
+    parts = []
+    for elem in elements:
+        if isinstance(elem, dict):
+            if "text" in elem:
+                parts.append(elem["text"])
+            if "elements" in elem:
+                parts.append(_extract_rich_text_elements(elem["elements"]))
+    return " ".join(parts)
+
+
+def extract_full_text(msg: dict) -> str:
+    """メッセージの text / blocks / attachments からテキストを結合して返す"""
+    parts = []
+
+    # text フィールド
+    text = msg.get("text") or ""
+    if text:
+        parts.append(text)
+
+    # blocks フィールド
+    for block in msg.get("blocks") or []:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+        if btype in ("section", "header"):
+            block_text = block.get("text")
+            if isinstance(block_text, dict):
+                parts.append(block_text.get("text", ""))
+        elif btype == "rich_text":
+            for elem in block.get("elements") or []:
+                if isinstance(elem, dict) and "elements" in elem:
+                    parts.append(_extract_rich_text_elements(elem["elements"]))
+
+    # attachments フィールド
+    for att in msg.get("attachments") or []:
+        if not isinstance(att, dict):
+            continue
+        for key in ("text", "fallback", "pretext"):
+            val = att.get(key) or ""
+            if val:
+                parts.append(val)
+
+    return " ".join(parts)
+
 
 def parse_arguments():
     """コマンドライン引数をパースする"""
@@ -28,10 +77,11 @@ def parse_arguments():
     parser.add_argument("--keyword", required=True, help="検索キーワード（完全一致）")
     parser.add_argument("--days", type=int, default=30, help="検索する過去日数 (デフォルト: 30)")
     parser.add_argument("--output", required=True, help="出力JSONファイルパス")
+    parser.add_argument("--no-replies", action="store_true", help="スレッド返信を除外し親メッセージのみ集計")
     return parser.parse_args()
 
 
-def fetch_messages(client: WebClient, channel_id: str, keyword: str, days: int) -> List[Dict]:
+def fetch_messages(client: WebClient, channel_id: str, keyword: str, days: int, include_replies: bool = True) -> List[Dict]:
     """
     conversations.history + conversations.replies でメッセージを取得し、
     キーワードフィルタ＋重複排除して返す。
@@ -41,31 +91,7 @@ def fetch_messages(client: WebClient, channel_id: str, keyword: str, days: int) 
     keyword_lower = keyword.lower()
 
     # conversations.history で期間内の全メッセージ取得
-    all_channel_messages = []
-    try:
-        cursor = None
-        while True:
-            response = client.conversations_history(
-                channel=channel_id,
-                oldest=str(oldest),
-                latest=str(latest),
-                limit=200,
-                cursor=cursor
-            )
-            if not response["ok"]:
-                print(f"Error: {response.get('error', 'Unknown error')}", file=sys.stderr)
-                sys.exit(1)
-
-            all_channel_messages.extend(response.get("messages", []))
-
-            if response.get("has_more") and response.get("response_metadata", {}).get("next_cursor"):
-                cursor = response["response_metadata"]["next_cursor"]
-                time.sleep(1.5)  # Tier 3
-            else:
-                break
-    except SlackApiError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    all_channel_messages = fetch_all_channel_history(client, channel_id, oldest=oldest, latest=latest)
 
     print(f"Fetched {len(all_channel_messages)} messages from channel history.")
 
@@ -75,7 +101,7 @@ def fetch_messages(client: WebClient, channel_id: str, keyword: str, days: int) 
 
     for msg in all_channel_messages:
         # 親メッセージのチェック
-        text = msg.get("text", "")
+        text = extract_full_text(msg)
         ts = msg.get("ts")
         if keyword_lower in text.lower():
             normalized_text = text.strip().lower()
@@ -84,38 +110,20 @@ def fetch_messages(client: WebClient, channel_id: str, keyword: str, days: int) 
                 messages.append(msg)
 
         # スレッドがある場合は返信も検索
-        if msg.get("reply_count", 0) > 0:
+        if include_replies and msg.get("reply_count", 0) > 0:
             try:
-                reply_cursor = None
-                while True:
-                    reply_response = client.conversations_replies(
-                        channel=channel_id,
-                        ts=ts,
-                        oldest=str(oldest),
-                        latest=str(latest),
-                        limit=200,
-                        cursor=reply_cursor
-                    )
-                    if not reply_response["ok"]:
-                        break
+                replies = fetch_all_thread_replies(
+                    client, channel_id, ts, oldest=oldest, latest=latest
+                )
+                for reply in replies:
+                    reply_text = extract_full_text(reply)
+                    if keyword_lower in reply_text.lower():
+                        normalized_reply = reply_text.strip().lower()
+                        if normalized_reply not in seen_texts:
+                            seen_texts.add(normalized_reply)
+                            messages.append(reply)
 
-                    replies = reply_response.get("messages", [])
-                    # 最初のページでは親メッセージ（index 0）をスキップ
-                    for reply in (replies[1:] if reply_cursor is None else replies):
-                        reply_text = reply.get("text", "")
-                        if keyword_lower in reply_text.lower():
-                            normalized_reply = reply_text.strip().lower()
-                            if normalized_reply not in seen_texts:
-                                seen_texts.add(normalized_reply)
-                                messages.append(reply)
-
-                    if reply_response.get("has_more") and reply_response.get("response_metadata", {}).get("next_cursor"):
-                        reply_cursor = reply_response["response_metadata"]["next_cursor"]
-                        time.sleep(1.5)  # Tier 3
-                    else:
-                        break
-
-                time.sleep(1.5)  # Tier 3
+                time.sleep(1.5)  # Tier 3: スレッド間の追加待機
             except SlackApiError as e:
                 print(f"Warning: Failed to fetch replies for thread {ts}: {e}", file=sys.stderr)
 
@@ -204,10 +212,11 @@ def main():
     # Slack クライアントを初期化
     client = WebClient(token=args.token)
 
+    include_replies = not args.no_replies
     print(f"Searching for messages containing '{args.keyword}' in channel {args.channel}...")
-    print(f"Search period: last {args.days} days")
+    print(f"Search period: last {args.days} days, replies: {'included' if include_replies else 'excluded'}")
 
-    messages = fetch_messages(client, args.channel, args.keyword, args.days)
+    messages = fetch_messages(client, args.channel, args.keyword, args.days, include_replies=include_replies)
 
     if not messages:
         print(f"\nNo messages found containing '{args.keyword}' in the specified period.")


### PR DESCRIPTION
## Summary
レート制限の処理を一元化・強化し、Slack Conversations API呼び出し用の共有モジュールを追加し、テストカバレッジを向上させることで、Slack関連のPythonスクリプトに大幅な改善をもたらす。

This pull request introduces significant improvements to the Slack-related Python scripts by centralizing and enhancing rate limit handling, adding a shared module for Slack conversations API calls, and increasing test coverage. The most important changes are as follows:

**Rate Limit Handling Improvements:**

* Introduced a new shared module `slack_rate_limit.py` with an improved `handle_rate_limit` function that handles Slack API rate limits using the `Retry-After` header and exponential backoff, and is now imported and used across other modules instead of duplicating the logic. <a>[1]</a> <a>[2]</a> <a>[3]</a>

**Slack Conversations API Abstraction:**

* Added `slack_conversations.py`, a new shared module that abstracts and centralizes the logic for paginated and rate-limited calls to Slack's `conversations.history` and `conversations.replies` APIs, making it easier for scripts to fetch messages and thread replies.
* Fixed a bug in `fetch_thread_replies` where `is_first_page` was only set to `False` when replies were non-empty, causing the second page to incorrectly drop its first message when the first page returned an empty list.

**Bug Fixes and Consistency:**

* Updated `get_channel_last_message_time` in `inactive_channels.py` to always return a UTC-aware `datetime` object, ensuring consistent timezone handling.

**Testing Enhancements:**

* Added a comprehensive new test suite `tests/test_inactive_channels.py` to cover channel loading, message time retrieval, inactive channel checks, and result saving logic, improving reliability and maintainability.
* Added a comprehensive new test suite `tests/test_slack_conversations.py` covering cursor pagination (`has_more`/`next_cursor` handling), `skip_parent` behavior across single and multi-page scenarios, rate-limit retry logic, and edge cases such as empty responses and `ok=False`.
* Improved mock response construction in `tests/test_slack_search.py` for better test consistency and clarity.